### PR TITLE
Add 'run' command to start Docker containers

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,1 @@
+export * from "./run";

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,0 +1,30 @@
+import ora from "ora";
+import chalk from "chalk";
+
+export const run = async () => {
+  const spinner = ora("Starting Docker containers...\n").start();
+
+  try {
+    const { execSync } = require("child_process");
+    const { access } = require("fs/promises");
+
+    const composePath = "./kage/docker-compose.yml";
+
+    try {
+      await access(composePath);
+    } catch {
+      throw new Error(
+        "Docker Compose file not found. Please run 'kage init' first."
+      );
+    }
+
+    execSync(`docker-compose -f ${composePath} up -d`, {
+      stdio: "inherit",
+    });
+
+    spinner.succeed("Docker containers started successfully!");
+  } catch (error: any) {
+    spinner.fail(chalk.red(`Error: ${error.message}`));
+    process.exit(1);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { DockerBuilder } from "./builders/docker-builder";
 import inquirer from "inquirer";
 import chalk from "chalk";
 import ora from "ora";
+import { run } from "./commands";
 
 async function main() {
   const program = new Command();
@@ -93,6 +94,11 @@ async function main() {
       process.exit(1);
     }
   });
+
+  program
+    .command("run")
+    .description("Start the Docker containers")
+    .action(run);
 
   program.parse();
 }


### PR DESCRIPTION
- Implemented a new command in the CLI to start Docker containers using docker-compose.
- Created a new 'run' module that checks for the existence of the Docker Compose file and executes the command to bring up the containers.
- Added error handling to inform users if the Docker Compose file is missing, prompting them to run 'kage init' first.